### PR TITLE
Fix version not active error when moving versions

### DIFF
--- a/lib/kms_encrypted/database.rb
+++ b/lib/kms_encrypted/database.rb
@@ -48,7 +48,7 @@ module KmsEncrypted
 
       KmsEncrypted::Box.new(
         key_id: key_id,
-        version: version,
+        version: self.version,
         previous_versions: previous_versions
       ).decrypt(ciphertext, context: context)
     end

--- a/lib/kms_encrypted/database.rb
+++ b/lib/kms_encrypted/database.rb
@@ -48,6 +48,7 @@ module KmsEncrypted
 
       KmsEncrypted::Box.new(
         key_id: key_id,
+        version: version,
         previous_versions: previous_versions
       ).decrypt(ciphertext, context: context)
     end


### PR DESCRIPTION
This change just explicitly sets the version on new KmsEncrypted::Box objects when decrypting. This gem works fine when you're only using 1 version, but if you are using a version > 1, it fails to decrypt, because of a version mismatch, due to the version parameter never being passed and it defaulting to 1 (when the ciphertext is v2).

I detailed it in an issue, [here](https://github.com/ankane/kms_encrypted/issues/24).