### PR TITLE
Use standalone SDK for Google KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ KMS_KEY_ID=alias/my-alias
 Add this line to your application’s Gemfile:
 
 ```ruby
-gem 'google-api-client'
+gem 'google-apis-cloudkms_v1'
 ```
 
 Create a [Google Cloud Platform](https://cloud.google.com/) account if you don’t have one. KMS works great whether or not you run your infrastructure on GCP.

--- a/kms_encrypted.gemspec
+++ b/kms_encrypted.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "attr_encrypted"
   spec.add_development_dependency "lockbox", ">= 0.4.7"
   spec.add_development_dependency "aws-sdk-kms"
-  spec.add_development_dependency "google-api-client"
+  spec.add_development_dependency "google-apis-cloudkms_v1"
   spec.add_development_dependency "vault"
   spec.add_development_dependency "carrierwave"
 end


### PR DESCRIPTION
I'm not sure when this happened, but Google now splits their giant SDK bundle gem into lots of small gems.