### PR TITLE
Allow AWS credentials to be overridden with library configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0 (2024-08-22)
+
+- Added ability to override AWS credentials using a global configuration
+
 ## 1.6.0 (2024-06-24)
 
 - Dropped support for Ruby < 3.1 and Rails < 6.1

--- a/README.md
+++ b/README.md
@@ -321,6 +321,23 @@ And create a token with specific policies with:
 vault token create -policy=encrypt -policy=decrypt -no-default-policy
 ```
 
+## Configuration
+
+If you need to override which set of AWS credentials are used by the `Aws::KMS` SDK under the hood, you can specify the
+credentials via the `configure` class method:
+
+```ruby
+KmsEncrypted.configure do |config|
+  config.aws_access_key_id = '123456'
+  config.aws_secret_access_key = 'abcdef'
+end
+```
+
+In a Rails application, you can place this code in an initializer file. For example: `config/initializers/kms_encrypted.rb`.
+
+The use-case here would be if your KMS key exists on a separate account from what is specified via your
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+
 ## Testing
 
 For testing, you can prevent network calls to KMS by setting:

--- a/lib/kms_encrypted/version.rb
+++ b/lib/kms_encrypted/version.rb
@@ -1,3 +1,3 @@
 module KmsEncrypted
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/test/kms_encrypted_test.rb
+++ b/test/kms_encrypted_test.rb
@@ -203,6 +203,25 @@ class KmsEncryptedTest < Minitest::Test
     user.rotate_kms_key!
   end
 
+  def test_config_overrides
+    assert_equal(
+      ENV['AWS_ACCESS_KEY_ID'],
+      KmsEncrypted.aws_client.config.credentials.access_key_id
+    )
+
+    config_access_key_id = 'config-access-key-id'
+
+    KmsEncrypted.configure do |config|
+      config.aws_access_key_id = config_access_key_id
+      config.aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+    end
+
+    assert_equal(
+      config_access_key_id,
+      KmsEncrypted.aws_client(force_reload: true).config.credentials.access_key_id
+    )
+  end
+
   private
 
   def assert_operations(expected)


### PR DESCRIPTION
## Overview

We're in the process of moving our application from Heroku to AWS (managed by a service called FlightControl).

Since FlightControl is working as a PaaS that's managing our AWS resources for us, they have their own `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` ENV vars that they need to control and need to be left alone.

And since we have a lot of data that's already encrypted using our KMS key on the AWS account that we manage, we'd like to be able to leave all of that encrypted data alone. Therefore, we need to be able to specify a separate set of AWS credentials to be used only for KMS, so that it won't automatically pick up `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.

## Testing
```sh
➜  kms_encrypted git:(allow-aws-creds-to-be-overridden) bundle exec rake test
Run options: --seed 63021

# Running:

.........S..................

Fabulous run in 0.058985s, 474.6970 runs/s, 847.6731 assertions/s.

28 runs, 50 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```